### PR TITLE
Updated static page

### DIFF
--- a/rockpi-penta/etc/rockpi-penta.conf
+++ b/rockpi-penta/etc/rockpi-penta.conf
@@ -29,6 +29,8 @@ press = 1.8
 # Whether the oled auto display next page and the time interval (seconds)
 auto = true
 time = 10
+# Specify a fixed page (0, 1, or 2) for use if auto is set to false
+page = 0
 
 [oled]
 # Whether rotate the text of oled 180 degrees, whether use Fahrenheit

--- a/rockpi-penta/usr/bin/rockpi-penta/misc.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/misc.py
@@ -69,6 +69,7 @@ def read_conf():
         # other
         conf['slider']['auto'] = cfg.getboolean('slider', 'auto')
         conf['slider']['time'] = cfg.getfloat('slider', 'time')
+        conf['slider']['page'] = cfg.getint('slider', 'page', fallback=0)
         conf['oled']['rotate'] = cfg.getboolean('oled', 'rotate')
         conf['oled']['f-temp'] = cfg.getboolean('oled', 'f-temp')
     except Exception:
@@ -140,6 +141,8 @@ def get_disk_info(cache={}):
 
 
 def slider_next(pages):
+    if len(pages.keys()) == 1:
+        return list(pages.values())[0]
     conf['idx'].value += 1
     return pages[conf['idx'].value % len(pages)]
 

--- a/rockpi-penta/usr/bin/rockpi-penta/oled.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/oled.py
@@ -80,36 +80,43 @@ def put_disk_info():
     return page
 
 
-def gen_pages():
-    pages = {
-        0: [
+def gen_pages(pages):
+    if pages == None:
+        pages = [0, 1, 2]
+    result = {}
+    if 0 in pages:
+        result[0] = [
             {'xy': (0, -2), 'text': misc.get_info('up'), 'fill': 255, 'font': font['11']},
             {'xy': (0, 10), 'text': misc.get_cpu_temp(), 'fill': 255, 'font': font['11']},
             {'xy': (0, 21), 'text': misc.get_info('ip'), 'fill': 255, 'font': font['11']},
-        ],
-        1: [
+        ]
+    if 1 in pages:
+        result[1] = [
             {'xy': (0, 2), 'text': misc.get_info('cpu'), 'fill': 255, 'font': font['12']},
             {'xy': (0, 18), 'text': misc.get_info('men'), 'fill': 255, 'font': font['12']},
-        ],
-        2: put_disk_info()
-    }
+        ]
+    if 2 in pages:
+        result[2] = put_disk_info()
+    return result
 
-    return pages
 
-
-def slider(lock):
+def slider(lock, pages=None):
     with lock:
-        for item in misc.slider_next(gen_pages()):
+        for item in misc.slider_next(gen_pages(pages)):
             draw.text(**item)
         disp_show()
 
 
 def auto_slider(lock):
-    while misc.conf['slider']['auto']:
-        slider(lock)
+    pages = [0, 1, 2]
+
+    if not misc.conf['slider']['auto']:
+        if (static_page := misc.conf['slider'].get('page', 0)) in (0, 1, 2):
+            pages = [static_page]
+
+    while True:
+        slider(lock, pages)
         misc.slider_sleep()
-    else:
-        slider(lock)
 
 
 if __name__ == '__main__':

--- a/rockpi-penta/usr/bin/rockpi-penta/oled.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/oled.py
@@ -113,6 +113,8 @@ def auto_slider(lock):
     if not misc.conf['slider']['auto']:
         if (static_page := misc.conf['slider'].get('page', 0)) in (0, 1, 2):
             pages = [static_page]
+        else:
+            pages = [0]
 
     while True:
         slider(lock, pages)


### PR DESCRIPTION
I did not like the "sliding" display which would alternate between three different screens; one for uptime+CPU temp+IP, one for CPU+mem, and one for disk info. Instead, I just wanted one specific page (the first one in my case) to be shown permanently.

While this was possible by setting _auto_ (under the [slider] section to false, the status would never refresh, making the information not very useful. This was especially true when the page would update before an IP address was obtained from the DHCP server on boot, meaning the IP would never show.

With the changes here, I have introduced a new _page_ option (also under [slider]). This only comes into play if _auto_ is set to false, and it allows the user to pick a single page (0, 1 or 2) to permanently show. This page will refresh at the interval specified by _time_ (in seconds), which would otherwise be used to indicate the interval of a page transition.

If _auto_ is false but _page_ is not set to either 0, 1, or 2, it will fall back to 0.