### PR TITLE
Allow configuring which disks/mount points to show on screen

### DIFF
--- a/rockpi-penta/etc/rockpi-penta.conf
+++ b/rockpi-penta/etc/rockpi-penta.conf
@@ -34,3 +34,14 @@ time = 10
 # Whether rotate the text of oled 180 degrees, whether use Fahrenheit
 rotate = false
 f-temp = false
+
+# Allow defining additional disks to display (max of 4, others are not shown)
+# The name of the disk is shown on the OLED screen, but will be truncated to
+# five characters.
+#
+# An example to show two additional drives on the OLED screen
+# is as follows:
+# [disk]
+# media = md0
+# home = sda1
+# <NAME SHOWN ON OLED SCREEN> = <DEVICE>

--- a/rockpi-penta/usr/bin/rockpi-penta/misc.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/misc.py
@@ -71,6 +71,9 @@ def read_conf():
         conf['slider']['time'] = cfg.getfloat('slider', 'time')
         conf['oled']['rotate'] = cfg.getboolean('oled', 'rotate')
         conf['oled']['f-temp'] = cfg.getboolean('oled', 'f-temp')
+        # disks
+        if 'disk' in cfg.sections():
+            conf['disk'] = cfg['disk']
     except Exception:
         traceback.print_exc()
         # fan
@@ -130,9 +133,9 @@ def get_disk_info(cache={}):
         info = {}
         cmd = "df -h | awk '$NF==\"/\"{printf \"%s\", $5}'"
         info['root'] = check_output(cmd)
-        for x in conf['disk']:
-            cmd = "df -Bg | awk '$1==\"/dev/{}\" {{printf \"%s\", $5}}'".format(x)
-            info[x] = check_output(cmd)
+        for name in conf['disk']:
+            cmd = "df -Bg | awk '$1==\"/dev/{}\" {{printf \"%s\", $5}}'".format(conf['disk'][name])
+            info[name] = check_output(cmd)
         cache['info'] = list(zip(*info.items()))
         cache['time'] = time.time()
 

--- a/rockpi-penta/usr/bin/rockpi-penta/misc.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/misc.py
@@ -31,10 +31,6 @@ def check_call(cmd):
     return subprocess.check_call(cmd, shell=True)
 
 
-def get_blk():
-    conf['disk'] = [x for x in check_output(cmds['blk']).strip().split('\n') if x.startswith('sd')]
-
-
 def get_info(s):
     return check_output(cmds[s])
 

--- a/rockpi-penta/usr/bin/rockpi-penta/oled.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/oled.py
@@ -58,7 +58,7 @@ def goodbye():
 
 def put_disk_info():
     k, v = misc.get_disk_info()
-    text1 = 'Disk: {} {}'.format(k[0], v[0])
+    text1 = 'Disk: {:>4} {:>3}'.format(k[0], v[0])
 
     if len(k) == 5:
         text2 = '{} {}  {} {}'.format(k[1], v[1], k[2], v[2])
@@ -73,6 +73,12 @@ def put_disk_info():
         page = [
             {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['12']},
             {'xy': (0, 18), 'text': text2, 'fill': 255, 'font': font['12']},
+        ]
+    elif len(k) == 2:
+        text2 = '{:>10} {:>3}'.format(k[1], v[1])
+        page = [
+            {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['14']},
+            {'xy': (0, 19), 'text': text2, 'fill': 255, 'font': font['14']},
         ]
     else:
         page = [{'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['14']}]

--- a/rockpi-penta/usr/bin/rockpi-penta/oled.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/oled.py
@@ -58,9 +58,9 @@ def goodbye():
 
 def put_disk_info():
     k, v = misc.get_disk_info()
-    text1 = 'Disk: {:>4} {:>3}'.format(k[0], v[0])
 
     if len(k) >= 5:
+        text1 = 'Disk:     {:>5} {:>3}'.format(k[0], v[0])
         text2 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[1], v[1], k[2], v[2])
         text3 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[3], v[3], k[4], v[4])
         page = [
@@ -69,6 +69,7 @@ def put_disk_info():
             {'xy': (0, 21), 'text': text3, 'fill': 255, 'font': font['10']},
         ]
     elif len(k) == 4:
+        text1 = 'Disk:     {:>5} {:>3}'.format(k[0], v[0])
         text2 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[1], v[1], k[2], v[2])
         text3 = '{:>5.5} {:>3}'.format(k[3], v[3])
         page = [
@@ -77,20 +78,22 @@ def put_disk_info():
             {'xy': (0, 21), 'text': text3, 'fill': 255, 'font': font['10']},
         ]
     elif len(k) == 3:
+        text1 = 'Disk:     {:>5} {:>3}'.format(k[0], v[0])
         text2 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[1], v[1], k[2], v[2])
         page = [
             {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['11']},
             {'xy': (0, 18), 'text': text2, 'fill': 255, 'font': font['11']},
         ]
     elif len(k) == 2:
+        text1 = 'Disk: {:>4} {:>3}'.format(k[0], v[0])
         text2 = '{:>10} {:>3}'.format(k[1], v[1])
         page = [
             {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['14']},
             {'xy': (0, 19), 'text': text2, 'fill': 255, 'font': font['14']},
         ]
     else:
+        text1 = 'Disk: {:>4} {:>3}'.format(k[0], v[0])
         page = [{'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['14']}]
-
 
     return page
 

--- a/rockpi-penta/usr/bin/rockpi-penta/oled.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/oled.py
@@ -60,19 +60,27 @@ def put_disk_info():
     k, v = misc.get_disk_info()
     text1 = 'Disk: {:>4} {:>3}'.format(k[0], v[0])
 
-    if len(k) == 5:
-        text2 = '{} {}  {} {}'.format(k[1], v[1], k[2], v[2])
-        text3 = '{} {}  {} {}'.format(k[3], v[3], k[4], v[4])
+    if len(k) >= 5:
+        text2 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[1], v[1], k[2], v[2])
+        text3 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[3], v[3], k[4], v[4])
         page = [
-            {'xy': (0, -2), 'text': text1, 'fill': 255, 'font': font['11']},
-            {'xy': (0, 10), 'text': text2, 'fill': 255, 'font': font['11']},
-            {'xy': (0, 21), 'text': text3, 'fill': 255, 'font': font['11']},
+            {'xy': (0, -2), 'text': text1, 'fill': 255, 'font': font['10']},
+            {'xy': (0, 10), 'text': text2, 'fill': 255, 'font': font['10']},
+            {'xy': (0, 21), 'text': text3, 'fill': 255, 'font': font['10']},
+        ]
+    elif len(k) == 4:
+        text2 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[1], v[1], k[2], v[2])
+        text3 = '{:>5.5} {:>3}'.format(k[3], v[3])
+        page = [
+            {'xy': (0, -2), 'text': text1, 'fill': 255, 'font': font['10']},
+            {'xy': (0, 10), 'text': text2, 'fill': 255, 'font': font['10']},
+            {'xy': (0, 21), 'text': text3, 'fill': 255, 'font': font['10']},
         ]
     elif len(k) == 3:
-        text2 = '{} {}  {} {}'.format(k[1], v[1], k[2], v[2])
+        text2 = '{:>5.5} {:>3} {:>5.5} {:>3}'.format(k[1], v[1], k[2], v[2])
         page = [
-            {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['12']},
-            {'xy': (0, 18), 'text': text2, 'fill': 255, 'font': font['12']},
+            {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['11']},
+            {'xy': (0, 18), 'text': text2, 'fill': 255, 'font': font['11']},
         ]
     elif len(k) == 2:
         text2 = '{:>10} {:>3}'.format(k[1], v[1])
@@ -82,6 +90,7 @@ def put_disk_info():
         ]
     else:
         page = [{'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['14']}]
+
 
     return page
 


### PR DESCRIPTION
As I could not get any disk apart from the root filesystem to show on the OLED screen and it seemed based on my reading of the current code that this would never show anything except the root in it's current state I put together this PR.

This PR adds the ability to list up to four additional drives/mount points to display on the OLED screen as follows:

```
[disk]
media = md0
home = sdb1
```

The above config would show the free space for the filesystem on `/dev/md0` and `/dev/sdb1` on the screen along with the root filesystem similar to the following:

```
Disk:      root  8%
media 25%  home 18%
```

The root filesystem free space is always shown, and honestly the display of three or four additional devices means the text is quite small, but it at least gives this option.

This PR would fix #6 