### PR TITLE
Migrate to gpiod 2.x API and add configurable config file support

### DIFF
--- a/rockpi-penta/example_conf/rockpi-penta.conf
+++ b/rockpi-penta/example_conf/rockpi-penta.conf
@@ -1,0 +1,41 @@
+[fan]
+# When the temperature is above lv0 (35'C), the fan at 25% power,
+# and lv1 at 50% power, lv2 at 75% power, lv3 at 100% power.
+# When the temperature is below lv0, the fan is turned off.
+# You can change these values if necessary.
+lv0 = 35
+lv1 = 40
+lv2 = 45
+lv3 = 50
+
+[key]
+# You can customize the function of the key, currently available functions are
+# slider: oled display next page
+# switch: fan turn on/off switch
+# reboot, poweroff
+# If you have any good suggestions for key functions, 
+# please add an issue on https://github.com/radxa/rockpi-penta/issues
+click = slider
+twice = switch
+press = none
+
+[time]
+# twice: maximum time between double clicking (seconds)
+# press: long press time (seconds)
+twice = 0.7
+press = 1.8
+
+[slider]
+# Whether the oled auto display next page and the time interval (seconds)
+auto = true
+time = 10
+
+[oled]
+rotate = false
+# Whether rotate the text of oled 180 degrees, whether use Fahrenheit
+f-temp = false
+# oled goes to sleep after this time in seconds (0 to disable)
+sleep = 0
+
+[disk]
+extra = sdb1

--- a/rockpi-penta/usr/bin/rockpi-penta/fan.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/fan.py
@@ -49,14 +49,26 @@ class Gpio:
 
     def tr(self):
         while True:
-            self.line.set_value(1)
+            self.line_request.set_value(self.line_offset, gpiod.line.Value.ACTIVE)
             time.sleep(self.value[0])
-            self.line.set_value(0)
+            self.line_request.set_value(self.line_offset, gpiod.line.Value.INACTIVE)
             time.sleep(self.value[1])
 
     def __init__(self, period_s):
-        self.line = gpiod.Chip(os.environ['FAN_CHIP']).get_line(int(os.environ['FAN_LINE']))
-        self.line.request(consumer='fan', type=gpiod.LINE_REQ_DIR_OUT)
+        chip_path = os.environ['FAN_CHIP']
+        self.line_offset = int(os.environ['FAN_LINE'])
+        
+        self.chip = gpiod.Chip(chip_path)
+        self.line_request = self.chip.request_lines(
+            consumer='fan',
+            config={
+                self.line_offset: gpiod.LineSettings(
+                    direction=gpiod.line.Direction.OUTPUT,
+                    output_value=gpiod.line.Value.INACTIVE
+                )
+            }
+        )
+        
         self.value = [period_s / 2, period_s / 2]
         self.period_s = period_s
         self.thread = threading.Thread(target=self.tr, daemon=True)

--- a/rockpi-penta/usr/bin/rockpi-penta/main.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import queue
 import threading
 import traceback
@@ -26,6 +27,14 @@ action = {
 }
 
 
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='RockPi Penta HAT Controller')
+    parser.add_argument('-c', '--config', type=str, default='/etc/rockpi-penta.conf',
+                        help='Path to configuration file (default: /etc/rockpi-penta.conf)')
+    # Add more arguments here as needed
+    return parser.parse_args()
+
+
 def receive_key(q):
     while True:
         func = misc.get_func(q.get())
@@ -33,6 +42,8 @@ def receive_key(q):
 
 
 if __name__ == '__main__':
+    args = parse_arguments()
+    misc.init_conf(args.config)
 
     if top_board:
         oled.welcome()

--- a/rockpi-penta/usr/bin/rockpi-penta/misc.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/misc.py
@@ -5,6 +5,7 @@ import time
 import subprocess
 import multiprocessing as mp
 import traceback
+import argparse
 
 import gpiod
 from configparser import ConfigParser
@@ -48,12 +49,12 @@ def get_cpu_temp():
     return temp
 
 
-def read_conf():
+def read_conf(config_file):
     conf = defaultdict(dict)
 
     try:
         cfg = ConfigParser()
-        cfg.read('/etc/rockpi-penta.conf')
+        cfg.read(config_file)
         # fan
         conf['fan']['lv0'] = cfg.getfloat('fan', 'lv0')
         conf['fan']['lv1'] = cfg.getfloat('fan', 'lv1')
@@ -71,7 +72,7 @@ def read_conf():
         conf['slider']['time'] = cfg.getfloat('slider', 'time')
         conf['oled']['rotate'] = cfg.getboolean('oled', 'rotate')
         conf['oled']['f-temp'] = cfg.getboolean('oled', 'f-temp')
-    except Exception:
+    except Exception as e:
         traceback.print_exc()
         # fan
         conf['fan']['lv0'] = 35
@@ -96,16 +97,23 @@ def read_conf():
 
 def read_key(pattern, size):
     CHIP_NAME = os.environ['BUTTON_CHIP']
-    LINE_NUMBER = os.environ['BUTTON_LINE']
+    LINE_NUMBER = int(os.environ['BUTTON_LINE'])
 
     s = ''
     chip = gpiod.Chip(str(CHIP_NAME))
-    line = chip.get_line(int(LINE_NUMBER))
-    line.request(consumer='hat_button', type=gpiod.LINE_REQ_DIR_OUT)
-    line.set_value(1)
+    line_request = chip.request_lines(
+        consumer='hat_button',
+        config={
+            LINE_NUMBER: gpiod.LineSettings(
+                direction=gpiod.line.Direction.OUTPUT,
+                output_value=gpiod.line.Value.ACTIVE
+            )
+        }
+    )
 
     while True:
-        s = s[-size:] + str(line.get_value())
+        value = line_request.get_value(LINE_NUMBER)
+        s = s[-size:] + str(int(value.value))
         for t, p in pattern.items():
             if p.match(s):
                 return t
@@ -163,5 +171,8 @@ def get_func(key):
     return conf['key'].get(key, 'none')
 
 
-conf = {'disk': [], 'idx': mp.Value('d', -1), 'run': mp.Value('d', 1)}
-conf.update(read_conf())
+def init_conf(config_file):
+    global conf
+    conf = {'disk': [], 'idx': mp.Value('d', -1), 'run': mp.Value('d', 1)}
+    conf.update(read_conf(config_file))
+

--- a/rockpi-penta/usr/bin/rockpi-penta/oled.py
+++ b/rockpi-penta/usr/bin/rockpi-penta/oled.py
@@ -47,10 +47,11 @@ def welcome():
     draw.text((0, 0), 'ROCKPi SATA HAT', font=font['14'], fill=255)
     draw.text((32, 16), 'Loading...', font=font['12'], fill=255)
     disp_show()
+    time.sleep(2)
 
 
 def goodbye():
-    draw.text((32, 8), 'Good Bye ~', font=font['14'], fill=255)
+    draw.text((32, 8), 'Good Bye', font=font['14'], fill=255)
     disp_show()
     time.sleep(2)
     disp_show()  # clear


### PR DESCRIPTION
- Upgrade GPIO handling to gpiod 2.x API (libgpiod 2.2.1)
  * Replace deprecated get_line() with request_lines()
  * Use gpiod.LineSettings for configuration
  * Update set_value/get_value to new API with line offsets
  * Apply changes to both fan.py (Gpio class) and misc.py (read_key)

- Add command-line argument support for config file
  * Add argparse support with -c/--config flag
  * Create parse_arguments() function in main.py
  * Add init_conf() function to initialize config from file
  * Default to /etc/rockpi-penta.conf if not specified

- Create new config file with proper [slider] section
  * Add rockpi-penta.conf with [slider] section
  * Move auto_slide and auto_slide_time from [oled] to [slider]
  * Rename keys to 'auto' and 'time' for consistency
  * Maintain backward compatibility with fallback defaults

- Refactor configuration loading
  * Make read_conf() accept config_file parameter
  * Move config initialization from module level to main
  * Config now loads after argument parsing

- Minor fixes
  * Add missing time.sleep(2) in oled welcome screen
  * Update goodbye message formatting